### PR TITLE
fix(fonts): Update typography.com fonts css reference URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>HSL Karttajulkaisin</title>
-    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6364294/6653152/css/fonts.css">
+    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6364294/7572592/css/fonts.css">
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
The typography.com fonts CSS URL is replaced with correct URL.