### PR TITLE
Add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Specify a non-default branch for pull requests for npm
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Raise pull requests for version updates
+    # to npm against the `development` branch
+    target-branch: "development"
+    # Labels on pull requests for version updates only
+    labels:
+      - "NPM Dependencies"


### PR DESCRIPTION
Dependabot config file for specifying a non-default branch for Dependabot PRs.