### PR TITLE
AB#64927: Truncate LineTimetable LineId

### DIFF
--- a/src/stores/generatorStore.js
+++ b/src/stores/generatorStore.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { stopsToRows, stopsToGroupRows, getVisibleRows, filterByStopMode } from '../util/stops';
 
 import commonStore from './commonStore';
+import { truncateLineId } from '../util/lines';
 
 const componentsByLabel = {
   Pysäkkijuliste: 'StopPoster',
@@ -222,7 +223,7 @@ store.generate = () => {
   });
 
   const lineTimetablePropsTemplate = id => ({
-    lineId: id,
+    lineId: truncateLineId(id), // Truncate the lineId to remove the letter postfixes
     dateBegin: store.dateBegin ? format(store.dateBegin) : null,
     dateEnd: store.dateEnd ? format(store.dateEnd) : null,
     printAsA5: true,

--- a/src/util/lines.js
+++ b/src/util/lines.js
@@ -20,4 +20,8 @@ function shortenTrainParsedLineId(lineId) {
   return lineId.replace(/^\d/, '');
 }
 
-export { TRANSPORTATION_MODES, compareLineNameOrder, shortenTrainParsedLineId };
+function truncateLineId(lineId) {
+  return lineId.substring(0, 4);
+}
+
+export { TRANSPORTATION_MODES, compareLineNameOrder, shortenTrainParsedLineId, truncateLineId };


### PR DESCRIPTION
Truncate the LineId when requesting LineTimetable posters so that the broad line query works as intended